### PR TITLE
Api routes

### DIFF
--- a/api/migrations/20210407180315-sequences.js
+++ b/api/migrations/20210407180315-sequences.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db) {
+  return db.runSql(`
+    ALTER SEQUENCE users_id_seq RESTART WITH 1000;
+    ALTER SEQUENCE appointments_id_seq RESTART WITH 1000;
+    ALTER SEQUENCE messages_id_seq RESTART WITH 1000;
+    ALTER SEQUENCE languages_id_seq RESTART WITH 1000;
+    ALTER SEQUENCE ratings_id_seq RESTART WITH 1000;
+    ALTER SEQUENCE user_languages_id_seq RESTART WITH 1000;
+  `);
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/api/src/loggedIn.js
+++ b/api/src/loggedIn.js
@@ -8,10 +8,12 @@ const isLoggedIn = (req, res, next) => {
     try {
       const token = jwt.verify(req.headers.authorization, process.env.JWT_SECRET);
       db.user.findOne({ where: { googleKey: token.googleKey } }).then((user) => {
+        console.log('name: ', user.name);
+        console.log('isStudent: ', user.student);
         if (user.student === null) {
           req.userAuthorized = false;
         } else {
-          req.userAuthorize = true;
+          req.userAuthorized = true;
         }
         req.user = user;
         req.accessToken = token.accessToken;

--- a/api/src/loggedIn.js
+++ b/api/src/loggedIn.js
@@ -8,16 +8,16 @@ const isLoggedIn = (req, res, next) => {
     try {
       const token = jwt.verify(req.headers.authorization, process.env.JWT_SECRET);
       db.user.findOne({ where: { googleKey: token.googleKey } }).then((user) => {
-        if (user.type === null) {
-          res.sendStatus(403);
+        if (user.student === null) {
+          req.userAuthorized = false;
         } else {
-          req.user = user;
-          req.accessToken = token.accessToken;
-          req.refreshToken = token.refreshToken;
-          next();
+          req.userAuthorize = true;
         }
+        req.user = user;
+        req.accessToken = token.accessToken;
+        req.refreshToken = token.refreshToken;
+        next();
       });
-      next();
     } catch (e) {
       res.sendStatus(403);
     }

--- a/api/src/postgres/index.js
+++ b/api/src/postgres/index.js
@@ -35,6 +35,7 @@ db.appointment.belongsTo(db.user, { foreignKey: 'from_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'to_id' });
 db.rating.belongsTo(db.appointment, { foreignKey: 'appointment_id' });
 db.language.belongsToMany(db.user, { through: db.user_languages });
+db.user.belongsToMany(db.language, { through: db.user_languages });
 
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {

--- a/api/src/postgres/index.js
+++ b/api/src/postgres/index.js
@@ -28,11 +28,15 @@ fs.readdirSync(path.join(__dirname, './models'))
 
 // Define relationships here
 db.message.belongsTo(db.user, { foreignKey: 'from_id' });
+db.user.hasMany(db.message, { as: 'sentMessages', hostKey: 'from_id' });
 db.message.belongsTo(db.user, { foreignKey: 'to_id' });
+db.user.hasMany(db.messsage, { as: 'incomingMessages', hostKey: 'to_id' });
 db.rating.belongsTo(db.user, { foreignKey: 'teacher_id' });
 db.rating.belongsTo(db.user, { foreignKey: 'student_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'from_id' });
+db.user.hasMany(db.appointment, { as: 'sentAppointments', hostKey: 'from_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'to_id' });
+db.user.hasMany(db.appointment, { as: 'incomingAppointments', hostKey: 'to_id' });
 db.rating.belongsTo(db.appointment, { foreignKey: 'appointment_id' });
 db.language.belongsToMany(db.user, { through: db.user_languages });
 db.user.belongsToMany(db.language, { through: db.user_languages });

--- a/api/src/postgres/index.js
+++ b/api/src/postgres/index.js
@@ -34,7 +34,7 @@ db.rating.belongsTo(db.user, { foreignKey: 'student_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'from_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'to_id' });
 db.rating.belongsTo(db.appointment, { foreignKey: 'appointment_id' });
-db.language.belongsToMany(db.user, { through: 'user_langauges' });
+db.language.belongsToMany(db.user, { through: 'user_languages' });
 
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {

--- a/api/src/postgres/index.js
+++ b/api/src/postgres/index.js
@@ -34,7 +34,7 @@ db.rating.belongsTo(db.user, { foreignKey: 'student_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'from_id' });
 db.appointment.belongsTo(db.user, { foreignKey: 'to_id' });
 db.rating.belongsTo(db.appointment, { foreignKey: 'appointment_id' });
-db.language.belongsToMany(db.user, { through: 'user_languages' });
+db.language.belongsToMany(db.user, { through: db.user_languages });
 
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {

--- a/api/src/postgres/models/user.js
+++ b/api/src/postgres/models/user.js
@@ -6,7 +6,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         primaryKey: true,
         autoIncrement: true,
-        defaultValue: 10,
       },
       name: {
         type: DataTypes.STRING,
@@ -52,7 +51,6 @@ module.exports = (sequelize, DataTypes) => {
       freezeTableName: true,
       tableName: 'users',
       timestamps: false,
-      initialAutoIncrement: 1000,
     }
   );
   return User;

--- a/api/src/postgres/models/user_languages.js
+++ b/api/src/postgres/models/user_languages.js
@@ -1,0 +1,29 @@
+module.exports = (sequelize, DataTypes) => {
+  const UserLanguages = sequelize.define(
+    'user_languages',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      languageId: {
+        field: 'language_id',
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      userId: {
+        field: 'user_id',
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+    },
+    {
+      freezeTableName: true,
+      tableName: 'user_languages',
+      timestamps: false,
+    }
+  );
+
+  return UserLanguages;
+};

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -2,7 +2,7 @@ const Router = require('express').Router();
 const jwt = require('jsonwebtoken');
 const isLoggedIn = require('../loggedIn');
 
-Router.use('/users', require('./users'));
+Router.use('/users', isLoggedIn, require('./users'));
 Router.use('/appointments', isLoggedIn, require('./appointments'));
 Router.use('/messages', isLoggedIn, require('./messages'));
 Router.use('/languages', isLoggedIn, require('./languages'));

--- a/api/src/routes/languages/index.js
+++ b/api/src/routes/languages/index.js
@@ -1,15 +1,90 @@
 const LanguagesRouter = require('express').Router();
+const db = require('../../postgres');
 
-LanguagesRouter.get('/', (req, res) => {
-  res.sendStatus(400);
+LanguagesRouter.get('/', async (req, res) => {
+  const page = req.query.page || 1;
+  const count = req.query.count || 100;
+  if (!req.userAuthorized) {
+    res.sendStatus(403);
+  } else {
+    try {
+      const result = await db.language.findAndCountAll({
+        limit: count,
+        offset: (page - 1) * count,
+      });
+      res.json({
+        count: Math.min(count, result.count),
+        page: page,
+        totalCount: result.count,
+        languages: result.rows.map((l) => ({ id: l.id, name: l.name })),
+      });
+    } catch (e) {
+      console.error(e);
+      res.sendStatus(500);
+    }
+  }
 });
 
-LanguagesRouter.get('/languages/:languageId/teachers', (req, res) => {
-  res.sendStatus(400);
+LanguagesRouter.get('/:languageId/teachers', async (req, res) => {
+  const page = req.query.page || 1;
+  const count = req.query.count || 10;
+  const languageId = req.params.languageId;
+  if (!req.userAuthorized) {
+    res.sendStatus(403);
+  } else {
+    try {
+      const result = await db.user.findAndCountAll({
+        where: { student: false },
+        include: {
+          model: db.language,
+          required: true,
+          where: {
+            id: languageId,
+          },
+        },
+      });
+      res.json({
+        count: Math.min(count, result.count),
+        page: page,
+        totalCount: result.count,
+        users: result.rows.map((u) => ({ id: u.id, name: u.name, bio: u.bio, profileImg: u.profileImg })),
+      });
+    } catch (e) {
+      console.error(e);
+      res.sendStatus(500);
+    }
+  }
 });
 
-LanguagesRouter.get('/languages/:languageId/students', (req, res) => {
-  res.sendStatus(400);
+LanguagesRouter.get('/:languageId/students', async (req, res) => {
+  const page = req.query.page || 1;
+  const count = req.query.count || 10;
+  const languageId = req.params.languageId;
+  if (!req.userAuthorized) {
+    res.sendStatus(403);
+  } else {
+    try {
+      const result = await db.user.findAndCountAll({
+        where: { student: true },
+        include: {
+          model: db.language,
+          required: true,
+          where: {
+            id: languageId,
+          },
+        },
+      });
+      res.json({
+        count: Math.min(count, result.count),
+        page: page,
+        totalCount: result.count,
+        users: result.rows.map((u) => ({ id: u.id, name: u.name, bio: u.bio, profileImg: u.profileImg })),
+      });
+    } catch (e) {
+      console.error(e);
+      res.sendStatus(500);
+    }
+  }
 });
 
 module.exports = LanguagesRouter;

--- a/api/src/routes/users/index.js
+++ b/api/src/routes/users/index.js
@@ -1,8 +1,11 @@
 const jwt = require('jsonwebtoken');
 
 const UsersRouter = require('express').Router();
+const db = require('../../postgres');
+
 
 UsersRouter.get('/', (req, res) => {
+<<<<<<< Updated upstream
   if (req.headers.authorization) {
     try {
       const token = jwt.verify(req.headers.authorization, process.env.JWT_SECRET);
@@ -13,18 +16,81 @@ UsersRouter.get('/', (req, res) => {
   } else {
     res.json({});
   }
+=======
+  db.user.findAll()
+  .then((data) => {
+		res.status(200).json(data);
+  })
+  .catch((err) =>
+		console.log(err)
+	);
+>>>>>>> Stashed changes
 });
 
 UsersRouter.get('/:userId', (req, res) => {
-  res.sendStatus(400);
+  var userId = req.params.userId;
+
+  db.user.findAll({
+    where: {
+      id: userId,
+    },
+  })
+  .then((data) => {
+		res.status(200).json(data);
+  })
+  .catch((err) =>
+		console.log(err)
+	);
 });
 
 UsersRouter.put('/type', (req, res) => {
-  res.sendStatus(400);
+  //what data am I getting from the front-end?
+  let isStudent = req.params.isStudent; //?????
+  let userId = req.params.userId;
+
+		db.user.update(
+			{ student: true },
+			{ where: { id: userId } }
+		)
+		.then(() => {
+			res.sendStatus(204);
+		})
+		.catch((err) => {
+			res.sendStatus(500);
+			console.log(err.message);
+		});
 });
 
-UsersRouter.post('/languages/:languageId', (req, res) => {
-  res.sendStatus(400);
+// UsersRouter.post('/languages/:languageId', (req, res) => {
+//   res.sendStatus(400);
+// });
+//following the api docs
+
+//multiple languages at a time?
+UsersRouter.post('/:userId/languages/:languageId', (req, res) => {
+  let userId = req.params.userId;
+  let languageId = req.params.languageId;
+  //console.log('query', req.query)
+  console.log('params', req.params)
+  //lang id
+  //console.log(db)
+  //user_langauges
+
+  db.language.findOne({
+    where: {id: languageId}
+  })
+  .then((data) => {
+    console.log('data', data);
+    const lang = data;
+    lang.addUser(userId)
+  })
+  .then(() => {
+    res.status(201).send('saved!');
+  })
+  .catch((err) => {
+    res.sendStatus(500);
+    console.log(err.message);
+  });
 });
 
 UsersRouter.get('/users/:userId/availability', (req, res) => {

--- a/api/src/routes/users/index.js
+++ b/api/src/routes/users/index.js
@@ -5,18 +5,6 @@ const db = require('../../postgres');
 
 
 UsersRouter.get('/', (req, res) => {
-<<<<<<< Updated upstream
-  if (req.headers.authorization) {
-    try {
-      const token = jwt.verify(req.headers.authorization, process.env.JWT_SECRET);
-      res.json(token.user);
-    } catch (e) {
-      res.json({});
-    }
-  } else {
-    res.json({});
-  }
-=======
   db.user.findAll()
   .then((data) => {
 		res.status(200).json(data);
@@ -24,7 +12,6 @@ UsersRouter.get('/', (req, res) => {
   .catch((err) =>
 		console.log(err)
 	);
->>>>>>> Stashed changes
 });
 
 UsersRouter.get('/:userId', (req, res) => {
@@ -64,23 +51,17 @@ UsersRouter.put('/type', (req, res) => {
 // UsersRouter.post('/languages/:languageId', (req, res) => {
 //   res.sendStatus(400);
 // });
-//following the api docs
 
-//multiple languages at a time?
 UsersRouter.post('/:userId/languages/:languageId', (req, res) => {
   let userId = req.params.userId;
   let languageId = req.params.languageId;
-  //console.log('query', req.query)
   console.log('params', req.params)
-  //lang id
-  //console.log(db)
-  //user_langauges
+
 
   db.language.findOne({
     where: {id: languageId}
   })
   .then((data) => {
-    console.log('data', data);
     const lang = data;
     lang.addUser(userId)
   })

--- a/api/src/routes/users/index.js
+++ b/api/src/routes/users/index.js
@@ -1,20 +1,8 @@
-const jwt = require('jsonwebtoken');
 const db = require('../../postgres');
 
 const UsersRouter = require('express').Router();
-const db = require('../../postgres');
-
 
 UsersRouter.get('/', (req, res) => {
-<<<<<<< HEAD
-  db.user.findAll()
-  .then((data) => {
-		res.status(200).json(data);
-  })
-  .catch((err) =>
-		console.log(err)
-	);
-=======
   if (req.headers.authorization) {
     try {
       const token = jwt.verify(req.headers.authorization, process.env.JWT_SECRET);
@@ -32,67 +20,59 @@ UsersRouter.get('/', (req, res) => {
   } else {
     res.json({});
   }
->>>>>>> staging
 });
 
 UsersRouter.get('/:userId', (req, res) => {
   var userId = req.params.userId;
 
-  db.user.findAll({
-    where: {
-      id: userId,
-    },
-  })
-  .then((data) => {
-		res.status(200).json(data);
-  })
-  .catch((err) =>
-		console.log(err)
-	);
+  db.user
+    .findOne({
+      where: {
+        id: userId,
+      },
+    })
+    .then((data) => {
+      res.status(200).json(data);
+    })
+    .catch((err) => console.log(err));
 });
 
 UsersRouter.put('/type', (req, res) => {
-  //what data am I getting from the front-end?
-  let isStudent = req.params.isStudent; //?????
-  let userId = req.params.userId;
-
-		db.user.update(
-			{ student: true },
-			{ where: { id: userId } }
-		)
-		.then(() => {
-			res.sendStatus(204);
-		})
-		.catch((err) => {
-			res.sendStatus(500);
-			console.log(err.message);
-		});
+  if (req.user.student === null) {
+    req.user.student = req.body.type === 'student';
+    req.user
+      .save()
+      .then((data) => {
+        res.sendStatus(204);
+      })
+      .catch(() => res.sendStatus(400));
+  } else {
+    res.sendStatus(400);
+  }
 });
 
 // UsersRouter.post('/languages/:languageId', (req, res) => {
 //   res.sendStatus(400);
 // });
 
-UsersRouter.post('/:userId/languages/:languageId', (req, res) => {
-  let userId = req.params.userId;
+UsersRouter.post('/languages/:languageId', (req, res) => {
   let languageId = req.params.languageId;
-  console.log('params', req.params)
 
-
-  db.language.findOne({
-    where: {id: languageId}
-  })
-  .then((data) => {
-    const lang = data;
-    lang.addUser(userId)
-  })
-  .then(() => {
-    res.status(201).send('saved!');
-  })
-  .catch((err) => {
-    res.sendStatus(500);
-    console.log(err.message);
-  });
+  db.language
+    .findOne({
+      where: { id: languageId },
+    })
+    .then((data) => {
+      const lang = data;
+      lang.addUser(req.user);
+    })
+    .then(() => {
+      res.status(201).send('saved!');
+    })
+    .catch((err) => {
+      res.sendStatus(500);
+      console.log(err.message);
+    });
 });
 
 UsersRouter.get('/users/:userId/availability', (req, res) => {


### PR DESCRIPTION
User routes complete (minus availability, as that needs calendar api integration).

Once again, modified isLoggedIn, it now will pass on ANY connected user, but will flag `req.userAuthorized` as false if they haven't set up a type yet. It's possible we need *two* middleware, one to fetch the user info from the database, and the other to actually authorize the user. But alas, no time.

User routes were the work of one wonderful Kate, I just cleaned it up a bit.

Added a user_languages model. You wouldn't think it would be needed, but sequelize assumes fields that aren't present if you don't manually tell it not to.

added a migration to set the 'autoIncrement' counters to 1000, so that the dummy data doesn't break things. You'll need to run `npm run postgres:migrate` again after pulling down these changes.